### PR TITLE
Update the v1.1.1 README.md to be accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,25 @@ yarn add strapi-middleware-upload-plugin-cache
 ```
 
 ## Setup
-For Strapi, add a ``plugins.js`` file within the config folder
+For Strapi, add a ``middlware.js`` file within the config folder (if you do not already have an exisiting config/middleware.js)
 
 e.g.
 ```
-touch config/plugins.js
+touch config/middleware.js
 ```
 
 containing
 
 ```
 module.exports = {
-  "upload-plugin-cache": {
-    enabled: true,
-    config: {
+  settings: {
+    "upload-plugin-cache": {
+      enabled: true,
       maxAge: 86_400_000,
-    },
+      config: {
+        maxAge: 86_400_000,
+      },
+    }
   }
 };
 ```
@@ -58,15 +61,17 @@ With the option ``dynamic: true`` files which are not cached on initializations 
 
 ```
 module.exports = {
-  "upload-plugin-cache": {
-    enabled: true,
-    config: {
-      maxAge: 86_400_000,
-      dynamic: true,
-      lruCache: {
-        max: 1000
+  settings: {
+    "upload-plugin-cache": {
+      enabled: true,
+      config: {
+        maxAge: 86_400_000,
+        dynamic: true,
+        lruCache: {
+          max: 1000
+        },
       },
-    },
+    }
   }
 };
 ```


### PR DESCRIPTION
I have updated the readme to match the accurate path for the configuration.  There is not a branch for 1.1.1 so I was unable to try to make the PR against that version.  I have not tested this for v4 so this PR may be irrelevant for that version, but the README.md on version 1.1.1 is incorrect.