### PR TITLE
fix undefined public dir path

### DIFF
--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -33,7 +33,7 @@ module.exports = ({ strapi }) => {
     {
       method: "GET",
       path: UPLOAD_PATH,
-      handler: [range, staticCache(strapi.dirs.public, { ...options, files })],
+      handler: [range, staticCache(strapi.dirs.static.public, { ...options, files })],
       config: { auth: false },
     },
   ]);


### PR DESCRIPTION
strapi.dirs.public were undifiend in v4.3 so i update it to strapi.dirs.static.public